### PR TITLE
Add annotation class

### DIFF
--- a/lib/analist/annotations.rb
+++ b/lib/analist/annotations.rb
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
 module Analist
+  class Annotation
+    attr_reader :receiver_type, :args_types, :return_type
+
+    def initialize(receiver_type, args_types, return_type)
+      @receiver_type = receiver_type.is_a?(Hash) ? receiver_type : { type: receiver_type }
+      @args_types = args_types
+      @return_type = return_type.is_a?(Hash) ? return_type : { type: return_type }
+    end
+
+    def ==(other)
+      return false unless other.is_a?(self.class)
+      [receiver_type, args_types, return_type] ==
+        [other.receiver_type, other.args_types, other.return_type]
+    end
+
+    def to_s
+      [receiver_type, args_types, return_type].to_s
+    end
+  end
+
+  class AnnotationTypeUnknown; end
+
   module Annotations
     module_function
 
@@ -8,40 +30,40 @@ module Analist
       {
         :+ => lambda do |annotated_children|
           {
-            Integer => [Integer, [Integer], Integer],
-            String => [String, [String], String],
-            Array => [Array, [Array], Array]
-          }[annotated_children.first.annotation.last]
+            Integer => Annotation.new(Integer, [Integer], Integer),
+            String => Annotation.new(String, [String], String),
+            Array => Annotation.new(Array, [Array], Array)
+          }[annotated_children.first.annotation.return_type[:type]]
         end,
-        upcase: ->(_) { [String, [], String] },
+        upcase: ->(_) { Annotation.new(String, [], String) },
         reverse: lambda do |annotated_children|
           {
-            String => [String, [], String],
-            Array => [Array, [], Array]
-          }[annotated_children.first.annotation.last]
+            String => Annotation.new(String, [], String),
+            Array => Annotation.new(Array, [], Array)
+          }[annotated_children.first.annotation.return_type[:type]]
         end,
         all: lambda do |annotated_children|
-          [
-            { type: annotated_children.first.annotation.last[:type], on: :collection },
+          Annotation.new(
+            { type: annotated_children.first.annotation.return_type[:type], on: :collection },
             [],
-            { type: annotated_children.first.annotation.last[:type], on: :collection }
-          ]
+            type: annotated_children.first.annotation.return_type[:type], on: :collection
+          )
         end,
         first: lambda do |annotated_children|
-          [
-            { type: annotated_children.first.annotation.last[:type], on: :collection },
+          Annotation.new(
+            { type: annotated_children.first.annotation.return_type[:type], on: :collection },
             [],
-            { type: annotated_children.first.annotation.last[:type], on: :instance }
-          ]
+            type: annotated_children.first.annotation.return_type[:type], on: :instance
+          )
         end
       }
     end
 
     def primitive_annotations
       {
-        int: ->(_) { [nil, [], Integer] },
-        str: ->(_) { [nil, [], String] },
-        const: ->(node) { [nil, [], type: node.children.last, on: :collection] }
+        int: ->(_) { Annotation.new(nil, [], Integer) },
+        str: ->(_) { Annotation.new(nil, [], String) },
+        const: ->(node) { Annotation.new(nil, [], type: node.children.last, on: :collection) }
       }
     end
   end

--- a/lib/analist/sql/create_statement.rb
+++ b/lib/analist/sql/create_statement.rb
@@ -21,7 +21,7 @@ module Analist
         end
       end
 
-      def find_type_for(column)
+      def lookup_type_for_method(column)
         self.class.sql_type_to_ast_type_map[columns[column]&.last]
       end
 

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -4,16 +4,34 @@ RSpec.describe Analist::Annotator do
   let(:schema) { Analist::SQL::Schema.read_from_file('./spec/support/sql/users.sql') }
 
   describe '#annotate' do
+    subject(:annotation) { annotated_node.annotation }
+
+    context 'when parsing an unknown property' do
+      let(:annotated_node) do
+        described_class.annotate(CommonHelpers.parse('a.unknown_property'))
+      end
+
+      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
+    end
+
+    context 'when parsing an unknown property on a primitive type' do
+      let(:annotated_node) do
+        described_class.annotate(CommonHelpers.parse('1.unknown_property'))
+      end
+
+      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
+    end
+
     context 'when parsing a simple calculation' do
       subject(:annotated_node) { described_class.annotate(CommonHelpers.parse('1 + 1')) }
 
-      it { expect(annotated_node.annotation).to eq [Integer, [Integer], Integer] }
+      it { expect(annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }
     end
 
     context 'when parsing a simple method call' do
       subject(:annotated_node) { described_class.annotate(CommonHelpers.parse('"word".reverse')) }
 
-      it { expect(annotated_node.annotation).to eq [String, [], String] }
+      it { expect(annotation).to eq Analist::Annotation.new(String, [], String) }
     end
 
     context 'when parsing a chained method call' do
@@ -22,11 +40,15 @@ RSpec.describe Analist::Annotator do
       end
 
       it { expect(annotated_node).to be_instance_of Analist::AnnotatedNode }
-      it { expect(annotated_node.annotation).to eq [String, [], String] }
-      it { expect(annotated_node.children.first.annotation).to eq [String, [], String] }
+      it { expect(annotation).to eq Analist::Annotation.new(String, [], String) }
+      it do
+        expect(annotated_node.children.first.annotation).to eq(
+          Analist::Annotation.new(String, [], String)
+        )
+      end
     end
 
-    context 'when parsing an Active Record object its property' do
+    context 'when parsing a known property on a Active Record object' do
       let(:annotated_node) do
         described_class.annotate(CommonHelpers.parse('User.first.id'), schema)
       end
@@ -34,8 +56,20 @@ RSpec.describe Analist::Annotator do
         described_class.annotate(CommonHelpers.parse('User.first.first_name'), schema)
       end
 
-      it { expect(annotated_node.annotation).to eq [{ type: :User, on: :instance }, [], Integer] }
-      it { expect(annotated_node2.annotation).to eq [{ type: :User, on: :instance }, [], String] }
+      it { expect(annotation).to eq Analist::Annotation.new({ type: :User }, [], Integer) }
+      it do
+        expect(annotated_node2.annotation).to eq(
+          Analist::Annotation.new({ type: :User }, [], String)
+        )
+      end
+    end
+
+    context 'when parsing an unknown property on a Active Record object' do
+      let(:annotated_node) do
+        described_class.annotate(CommonHelpers.parse('User.first.unknown_property'), schema)
+      end
+
+      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
     end
 
     context 'when parsing an Active Record collection' do
@@ -44,10 +78,10 @@ RSpec.describe Analist::Annotator do
       end
 
       it do
-        expect(annotated_node.annotation).to eq [
+        expect(annotated_node.annotation).to eq Analist::Annotation.new(
           { type: :User, on: :collection }, [],
-          { type: :User, on: :collection }
-        ]
+          type: :User, on: :collection
+        )
       end
     end
 
@@ -55,20 +89,28 @@ RSpec.describe Analist::Annotator do
       let(:annotated_node) { described_class.annotate(CommonHelpers.parse('"word".reverse')) }
       let(:annotated_node2) { described_class.annotate(CommonHelpers.parse('[1, 2, 3].reverse')) }
 
-      it { expect(annotated_node.annotation).to eq [String, [], String] }
-      it { expect(annotated_node2.annotation).to eq [Array, [], Array] }
+      it { expect(annotated_node.annotation).to eq Analist::Annotation.new(String, [], String) }
+      it { expect(annotated_node2.annotation).to eq Analist::Annotation.new(Array, [], Array) }
     end
 
     context 'when annotating nested statements' do
       subject(:annotated_node) { described_class.annotate(CommonHelpers.parse('[1] + ["a"]')) }
 
-      it { expect(annotated_node.annotation).to eq [Array, [Array], Array] }
-      it { expect(annotated_node.children.first.annotation).to eq [nil, [], Array] }
+      it { expect(annotated_node.annotation).to eq Analist::Annotation.new(Array, [Array], Array) }
       it do
-        expect(annotated_node.children[0].children.first.annotation).to eq [nil, [], Integer]
+        expect(annotated_node.children.first.annotation).to eq(
+          Analist::Annotation.new(nil, [], Array)
+        )
       end
       it do
-        expect(annotated_node.children[2].children.first.annotation).to eq [nil, [], String]
+        expect(annotated_node.children[0].children.first.annotation).to eq(
+          Analist::Annotation.new(nil, [], Integer)
+        )
+      end
+      it do
+        expect(annotated_node.children[2].children.first.annotation).to eq(
+          Analist::Annotation.new(nil, [], String)
+        )
       end
     end
   end

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Analist::Annotator do
         described_class.annotate(CommonHelpers.parse('a.unknown_property'))
       end
 
-      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
+      it { expect(annotation.return_type[:type]).to eq Analist::AnnotationTypeUnknown }
     end
 
     context 'when parsing an unknown property on a primitive type' do
@@ -19,7 +19,7 @@ RSpec.describe Analist::Annotator do
         described_class.annotate(CommonHelpers.parse('1.unknown_property'))
       end
 
-      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
+      it { expect(annotation.return_type[:type]).to eq Analist::AnnotationTypeUnknown }
     end
 
     context 'when parsing a simple calculation' do
@@ -56,10 +56,10 @@ RSpec.describe Analist::Annotator do
         described_class.annotate(CommonHelpers.parse('User.first.first_name'), schema)
       end
 
-      it { expect(annotation).to eq Analist::Annotation.new({ type: :User }, [], Integer) }
+      it { expect(annotation).to eq Analist::Annotation.new(:User, [], Integer) }
       it do
         expect(annotated_node2.annotation).to eq(
-          Analist::Annotation.new({ type: :User }, [], String)
+          Analist::Annotation.new(:User, [], String)
         )
       end
     end
@@ -69,7 +69,17 @@ RSpec.describe Analist::Annotator do
         described_class.annotate(CommonHelpers.parse('User.first.unknown_property'), schema)
       end
 
-      it { expect(annotation.return_type[:type]).to be_instance_of Analist::AnnotationTypeUnknown }
+      it { expect(annotation.return_type[:type]).to eq Analist::AnnotationTypeUnknown }
+      it do
+        expect(annotated_node.children.first.annotation).to eq(
+          Analist::Annotation.new({ type: :User, on: :collection }, [], type: :User, on: :instance)
+        )
+      end
+      it do
+        expect(annotated_node.children.first.children.first.annotation).to eq(
+          Analist::Annotation.new({ type: nil }, [], type: :User, on: :collection)
+        )
+      end
     end
 
     context 'when parsing an Active Record collection' do
@@ -79,8 +89,7 @@ RSpec.describe Analist::Annotator do
 
       it do
         expect(annotated_node.annotation).to eq Analist::Annotation.new(
-          { type: :User, on: :collection }, [],
-          type: :User, on: :collection
+          { type: :User, on: :collection }, [], type: :User, on: :collection
         )
       end
     end

--- a/spec/analist/checker_spec.rb
+++ b/spec/analist/checker_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Analist::Checker do
 
   let(:schema) { Analist::SQL::Schema.read_from_file('./spec/support/sql/users.sql') }
 
+  let(:expected_annotation) { checker.first.expected_annotation }
+  let(:actual_annotation) { checker.first.actual_annotation }
+
   describe '#check' do
     context 'when parsing a simple calculation' do
       let(:annotated_node) { Analist::Annotator.annotate(CommonHelpers.parse('1 + 1')) }
@@ -24,13 +27,6 @@ RSpec.describe Analist::Checker do
       it { expect(checker).to eq [] }
     end
 
-    context 'when parsing an invalid simple coercion' do
-      let(:annotated_node) { Analist::Annotator.annotate(CommonHelpers.parse('1 + "a"')) }
-
-      it { expect(checker.first.expected_annotation).to eq [Integer, [Integer], Integer] }
-      it { expect(checker.first.actual_annotation).to eq [Integer, [String], Integer] }
-    end
-
     context 'when parsing an invalid method call' do
       let(:annotated_node) { Analist::Annotator.annotate(CommonHelpers.parse('"a".reverse(1)')) }
 
@@ -39,14 +35,21 @@ RSpec.describe Analist::Checker do
       it { expect(checker.first.actual_number_of_args).to eq 1 }
     end
 
+    context 'when parsing an invalid simple coercion' do
+      let(:annotated_node) { Analist::Annotator.annotate(CommonHelpers.parse('1 + "a"')) }
+
+      it { expect(expected_annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }
+      it { expect(actual_annotation).to eq Analist::Annotation.new(Integer, [String], Integer) }
+    end
+
     context 'when parsing an invalid Active Record property coercion' do
       let(:annotated_node) do
         Analist::Annotator.annotate(CommonHelpers.parse('User.first.id + "a"'), schema)
       end
 
       it { expect(checker.first).to be_kind_of Analist::TypeError }
-      it { expect(checker.first.expected_annotation).to eq [Integer, [Integer], Integer] }
-      it { expect(checker.first.actual_annotation).to eq [Integer, [String], Integer] }
+      it { expect(expected_annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }
+      it { expect(actual_annotation).to eq Analist::Annotation.new(Integer, [String], Integer) }
     end
   end
 end


### PR DESCRIPTION
To distinguish between known and unknown method calls and to supply a simple interface to work with, `Annotation`s and `AnnotationTypeUnknown` have been added.