### PR TITLE
Handle method and class methods correctly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
 Metrics/AbcSize:
   Exclude:
     - 'lib/analist/annotator.rb'
+    - 'lib/analist/checker.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/support/**/*'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/analist/annotator.rb'
+
 Metrics/BlockLength:
   Exclude:
     - 'analist.gemspec'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,6 @@ Metrics/ModuleLength:
 
 Style/Documentation:
   Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
 
 Metrics/AbcSize:
   Exclude:
+    - 'lib/analist/annotations.rb'
     - 'lib/analist/annotator.rb'
     - 'lib/analist/checker.rb'
 

--- a/lib/analist/annotations.rb
+++ b/lib/analist/annotations.rb
@@ -35,13 +35,6 @@ module Analist
             Array => Annotation.new(Array, [Array], Array)
           }[receiver_return_type]
         end,
-        upcase: ->(_) { Annotation.new(String, [], String) },
-        reverse: lambda do |receiver_return_type|
-          {
-            String => Annotation.new(String, [], String),
-            Array => Annotation.new(Array, [], Array)
-          }[receiver_return_type]
-        end,
         all: lambda do |receiver_return_type|
           Annotation.new(
             { type: receiver_return_type, on: :collection },
@@ -55,7 +48,21 @@ module Analist
             [],
             type: receiver_return_type, on: :instance
           )
-        end
+        end,
+        new: lambda do |receiver_return_type|
+          Annotation.new(
+            { type: receiver_return_type, on: :collection },
+            [],
+            type: receiver_return_type, on: :instance
+          )
+        end,
+        reverse: lambda do |receiver_return_type|
+          {
+            String => Annotation.new(String, [], String),
+            Array => Annotation.new(Array, [], Array)
+          }[receiver_return_type]
+        end,
+        upcase: ->(_) { Annotation.new(String, [], String) }
       }
     end
 

--- a/lib/analist/annotator.rb
+++ b/lib/analist/annotator.rb
@@ -8,10 +8,14 @@ module Analist
   module Annotator
     module_function
 
-    def annotate(node, resources = nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/LineLength
+    def annotate(node, resources = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/LineLength
+      resources[:symbol_table] ||= SymbolTable.new
+
       return node unless node.respond_to?(:type)
 
       case node.type
+      when :args
+        annotate_args(node, resources)
       when :begin
         annotate_begin(node, resources)
       when :block
@@ -20,8 +24,10 @@ module Analist
         annotate_class(node, resources)
       when :module
         annotate_module(node, resources)
-      when :args
-        annotate_args(node, resources)
+      when :def
+        annotate_def(node, resources)
+      when :defs
+        annotate_defs(node, resources)
       when :send
         annotate_send(node, resources)
       when :array
@@ -30,9 +36,7 @@ module Analist
         annotate_local_variable_assignment(node, resources)
       when :lvar
         annotate_local_variable(node, resources)
-      when :dstr
-        annotate_dynamic_string(node, resources)
-      when :int, :str, :const
+      when :int, :str, :const, :dstr
         annotate_primitive(node)
       else
         if ENV['ANALIST_DEBUG']
@@ -46,16 +50,49 @@ module Analist
       annotate_begin(node, resources)
     end
 
+    def annotate_array(node, resources)
+      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
+                        Analist::Annotation.new(nil, [], Array))
+    end
+
     def annotate_begin(node, resources)
       AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
                         Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown))
     end
 
-    def annotate_block(node, resources)
-      SymbolTable.enter_scope
+    def annotate_block(node, resources, name = nil)
+      resources[:symbol_table].enter_scope(name)
       block = annotate_begin(node, resources)
-      SymbolTable.exit_scope
+      resources[:symbol_table].exit_scope
       block
+    end
+
+    def annotate_class(node, resources)
+      annotate_block(node, resources, node.children.first.children[1])
+    end
+
+    def annotate_def(node, resources)
+      annotate_block(node, resources, node.children.first)
+    end
+
+    def annotate_defs(node, resources)
+      annotate_block(node, resources, :"self.#{node.children[1]}")
+    end
+
+    def annotate_local_variable_assignment(node, resources)
+      annotated_children = node.children.map { |n| annotate(n, resources) }
+      variable, value = annotated_children
+
+      resources[:symbol_table].store(variable, value.annotation)
+
+      AnnotatedNode.new(node, annotated_children,
+                        Analist::Annotation.new(nil, [], value.annotation.return_type[:type]))
+    end
+
+    def annotate_local_variable(node, resources)
+      annotated_children = node.children.map { |n| annotate(n, resources) }
+      AnnotatedNode.new(node, annotated_children,
+                        resources[:symbol_table].retrieve(annotated_children.first))
     end
 
     def annotate_module(node, resources)
@@ -63,9 +100,9 @@ module Analist
                         Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown))
     end
 
-    def annotate_class(node, resources)
-      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
-                        Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown))
+    def annotate_primitive(node)
+      AnnotatedNode.new(node, node.children,
+                        Analist::Annotations.primitive_annotations[node.type].call(node))
     end
 
     def annotate_send(node, resources) # rubocop:disable Metrics/AbcSize
@@ -92,7 +129,7 @@ module Analist
 
       receiver_type = annotated_receiver.annotation.return_type if annotated_receiver
 
-      return_type = lookup_return_type_from_headers(annotated_children, resources[:headers]) ||
+      return_type = lookup_return_type_from_headers(annotated_children, resources) ||
                     lookup_return_type_from_schema(annotated_children, resources[:schema]) ||
                     AnnotationTypeUnknown
 
@@ -100,45 +137,23 @@ module Analist
                         Analist::Annotation.new(receiver_type, args, return_type))
     end
 
-    def annotate_array(node, resources)
-      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
-                        Analist::Annotation.new(nil, [], Array))
-    end
-
-    def annotate_local_variable_assignment(node, resources)
-      annotated_children = node.children.map { |n| annotate(n, resources) }
-      variable, value = annotated_children
-
-      SymbolTable.store(variable, value.annotation)
-
-      AnnotatedNode.new(node, annotated_children,
-                        Analist::Annotation.new(nil, [], value.annotation.return_type[:type]))
-    end
-
-    def annotate_local_variable(node, resources)
-      annotated_children = node.children.map { |n| annotate(n, resources) }
-      AnnotatedNode.new(node, annotated_children,
-                        SymbolTable.retrieve(annotated_children.first))
-    end
-
-    def annotate_primitive(node)
-      AnnotatedNode.new(node, node.children,
-                        Analist::Annotations.primitive_annotations[node.type].call(node))
-    end
-
-    def annotate_dynamic_string(node, _resources)
-      AnnotatedNode.new(node, node.children,
-                        Analist::Annotations.primitive_annotations[node.type].call(node))
-    end
-
-    def lookup_return_type_from_headers(annotated_children, headers)
-      return unless headers
-      return unless annotated_children.first
+    def lookup_return_type_from_headers(annotated_children, resources)
+      return unless resources[:headers]
 
       receiver, method = annotated_children
-      klass_name = receiver.annotation.return_type[:type].to_s
+      klass_name = if receiver
+                     receiver.annotation.return_type[:type].to_s
+                   else
+                     resources[:symbol_table].scope[0..-2].join('::')
+                   end
 
-      last_statement = headers.retrieve_method(method, klass_name)&.children&.last
+      method_name = if resources[:symbol_table].scope.last.to_s.start_with?('self.')
+                      :"self.#{method}"
+                    else
+                      method
+                    end
+
+      last_statement = resources[:headers].retrieve_method(method_name, klass_name)&.children&.last
       annotate(last_statement).annotation.return_type if last_statement
     end
 

--- a/lib/analist/annotator.rb
+++ b/lib/analist/annotator.rb
@@ -6,6 +6,10 @@ require 'analist/symbol_table'
 
 module Analist
   module Annotator
+    UNKNOWN_ANNOTATION_TYPE = Analist::Annotation.new(Analist::AnnotationTypeUnknown,
+                                                      Analist::AnnotationTypeUnknown,
+                                                      Analist::AnnotationTypeUnknown).freeze
+
     module_function
 
     def annotate(node, resources = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/LineLength
@@ -42,10 +46,7 @@ module Analist
         if ENV['ANALIST_DEBUG']
           raise NotImplementedError, "Node type `#{node.type}` cannot be annotated"
         end
-        AnnotatedNode.new(node, node.children,
-                          Analist::Annotation.new(Analist::AnnotationTypeUnknown,
-                                                  Analist::AnnotationTypeUnknown,
-                                                  Analist::AnnotationTypeUnknown))
+        AnnotatedNode.new(node, node.children, UNKNOWN_ANNOTATION_TYPE)
       end
     end
 
@@ -89,16 +90,14 @@ module Analist
       resources[:symbol_table].store(variable, value.annotation)
 
       AnnotatedNode.new(node, annotated_children,
-                        Analist::Annotation.new(nil, [], value.annotation.return_type.fetch(:type)))
+                        Analist::Annotation.new(nil, [], value.annotation.return_type))
     end
 
     def annotate_local_variable(node, resources)
       annotated_children = node.children.map { |n| annotate(n, resources) }
       AnnotatedNode.new(node, annotated_children,
                         resources[:symbol_table].retrieve(annotated_children.first) ||
-                        Analist::Annotation.new(Analist::AnnotationTypeUnknown,
-                                                Analist::AnnotationTypeUnknown,
-                                                Analist::AnnotationTypeUnknown))
+                        UNKNOWN_ANNOTATION_TYPE)
     end
 
     def annotate_module(node, resources)

--- a/lib/analist/checker.rb
+++ b/lib/analist/checker.rb
@@ -34,7 +34,7 @@ module Analist
       node.children.flat_map { |n| check(n) }.compact
     end
 
-    def check_send(node) # rubocop:disable Metrics/AbcSize
+    def check_send(node)
       return [] if node.annotation.return_type[:type] == Analist::AnnotationTypeUnknown
 
       receiver, _method_name, *args = node.children

--- a/lib/analist/headerizer.rb
+++ b/lib/analist/headerizer.rb
@@ -14,26 +14,49 @@ module Analist
       header_table
     end
 
-    def find_headers(node, header_table, scope: []) # rubocop:disable Metrics/AbcSize
+    def find_headers(node, header_table, scope = []) # rubocop:disable Metrics/CyclomaticComplexity
       return unless node
 
       case node.type
       when :begin
-        node.children.map { |n| find_headers(n, header_table, scope: scope) }
+        headerize_begin(node, header_table, scope)
       when :class
-        klass, superklass, body = node.children
-        namespace = to_namespace(klass)
-        header_table.store_class(namespace.last,
-                                 scope: scope + namespace[0..-2],
-                                 superklass: to_namespace(superklass).join('::'))
-        find_headers(body, header_table, scope: scope + namespace)
+        headerize_class(node, header_table, scope)
       when :def
-        method, = node.children
-        header_table.store_method(method, scope, node)
+        headerize_def(node, header_table, scope)
+      when :defs
+        headerize_defs(node, header_table, scope)
       when :module
-        namespace, body = node.children
-        find_headers(body, header_table, scope: scope + to_namespace(namespace))
+        headerize_module(node, header_table, scope)
       end
+    end
+
+    def headerize_begin(node, header_table, scope)
+      node.children.map { |n| find_headers(n, header_table, scope) }
+    end
+
+    def headerize_class(node, header_table, scope)
+      klass, superklass, body = node.children
+      namespace = to_namespace(klass)
+      header_table.store_class(namespace.last,
+                               scope: scope + namespace[0..-2],
+                               superklass: to_namespace(superklass).join('::'))
+      find_headers(body, header_table, scope + namespace)
+    end
+
+    def headerize_def(node, header_table, scope)
+      method, = node.children
+      header_table.store_method(method, scope, node)
+    end
+
+    def headerize_defs(node, header_table, scope)
+      _scope, method = node.children
+      header_table.store_method(:"self.#{method}", scope, node)
+    end
+
+    def headerize_module(node, header_table, scope)
+      namespace, body = node.children
+      find_headers(body, header_table, scope + to_namespace(namespace))
     end
 
     def to_namespace(node)

--- a/lib/analist/resolve_lookup.rb
+++ b/lib/analist/resolve_lookup.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Analist
+  module ResolveLookup
+    class Headers
+      def initialize(annotated_children, resources)
+        @headers = resources[:headers]
+        @symbol_table = resources[:symbol_table]
+
+        @receiver, @method = annotated_children
+      end
+
+      def return_type
+        return unless @headers
+
+        Analist::Annotator.annotate(last_statement).annotation.return_type if last_statement
+      end
+
+      def klass_method?
+        @symbol_table.current_scope_klass? ||
+          @receiver&.annotation&.return_type&.fetch(:on, nil) == :collection
+      end
+
+      def method_name
+        return :"self.#{@method}" if klass_method?
+        @method
+      end
+
+      def klass_name
+        return @receiver.annotation.return_type[:type].to_s if @receiver
+        @symbol_table.current_klass_name
+      end
+
+      def last_statement
+        @headers.retrieve_method(method_name, klass_name)&.children&.last
+      end
+    end
+
+    class Schema
+      def initialize(annotated_children, resources)
+        @schema = resources[:schema]
+        @receiver, @method = annotated_children
+      end
+
+      def return_type
+        return unless @schema
+        return unless @receiver
+        return unless @receiver.annotation.return_type[:on] == :instance
+        return unless @schema.table_exists?(table_name)
+
+        @schema[table_name].lookup_type_for_method(@method.to_s)
+      end
+
+      def table_name
+        @receiver.annotation.return_type[:type].to_s.downcase.pluralize
+      end
+    end
+  end
+end

--- a/lib/analist/sql/schema.rb
+++ b/lib/analist/sql/schema.rb
@@ -13,7 +13,7 @@ module Analist
 
       def_delegators :schema, :table_name, :find_type_for, :[]
 
-      def initialize(schema)
+      def initialize(schema = {})
         @schema = schema
       end
 

--- a/lib/analist/symbol_table.rb
+++ b/lib/analist/symbol_table.rb
@@ -2,38 +2,42 @@
 
 module Analist
   class SymbolTable
-    class << self
-      def table
-        @table ||= { 0 => {} }
-      end
+    def table
+      @table ||= { 0 => {} }
+    end
 
-      def level
-        @level ||= 0
-      end
+    def level
+      @level ||= 0
+    end
 
-      def store(symbol, annotation)
-        table[level][symbol] = annotation
-      end
+    def scope
+      @scope ||= []
+    end
 
-      def retrieve(symbol, l = level)
-        return if l.negative?
+    def store(symbol, annotation)
+      table[level][symbol] = annotation
+    end
 
-        if table[l].key?(symbol)
-          table[l][symbol]
-        else
-          retrieve(symbol, l - 1)
-        end
-      end
+    def retrieve(symbol, l = level)
+      return if l.negative?
 
-      def enter_scope
-        @level = level + 1
-        table[level] = {}
+      if table[l].key?(symbol)
+        table[l][symbol]
+      else
+        retrieve(symbol, l - 1)
       end
+    end
 
-      def exit_scope
-        table.delete(level)
-        @level = level - 1
-      end
+    def enter_scope(name = nil)
+      scope << name
+      @level = level + 1
+      table[level] = {}
+    end
+
+    def exit_scope
+      scope.pop
+      table.delete(level)
+      @level = level - 1
     end
   end
 end

--- a/lib/analist/symbol_table.rb
+++ b/lib/analist/symbol_table.rb
@@ -39,5 +39,13 @@ module Analist
       table.delete(level)
       @level = level - 1
     end
+
+    def current_scope_klass?
+      scope.last.to_s.start_with?('self.')
+    end
+
+    def current_klass_name
+      resources[:symbol_table].scope[0..-2].join('::')
+    end
   end
 end

--- a/lib/analist/symbol_table.rb
+++ b/lib/analist/symbol_table.rb
@@ -45,7 +45,7 @@ module Analist
     end
 
     def current_klass_name
-      resources[:symbol_table].scope[0..-2].join('::')
+      scope[0..-2].join('::')
     end
   end
 end

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating an user-defined instance method' do
+    context 'when annotating a user-defined instance method' do
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/user.rb') }
 
       let(:expression) { 'User.first.full_name' }
@@ -114,7 +114,7 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating an user-defined instance method as class method' do
+    context 'when annotating a user-defined instance method as class method' do
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/user.rb') }
 
       let(:expression) { 'User.full_name' }
@@ -125,7 +125,7 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating an user-defined class method on a Active Record collection' do
+    context 'when annotating a user-defined class method on a Active Record collection' do
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/user.rb') }
 
       let(:expression) { 'User.anonymous_name' }
@@ -264,7 +264,7 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating object creation' do
+    context 'when annotating variable assignment with object creation' do
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
       let(:expression) { 'var = Klass.new ; var.random_number' }
 

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -161,6 +161,21 @@ RSpec.describe Analist::Annotator do
       end
     end
 
+    context 'when annotating a variable assignment and reference on an object' do
+      let(:expression) { 'var = User.first ; var.id' }
+
+      it do
+        expect(annotated_node.children[0].annotation).to eq Analist::Annotation.new(
+          nil, [], type: :User, on: :instance
+        )
+      end
+      it do
+        expect(annotated_node.children[1].annotation).to eq Analist::Annotation.new(
+          { type: :User, on: :instance }, [], Integer
+        )
+      end
+    end
+
     context 'when annotating blocks, handle scope' do
       let(:expression) { 'var = 1 ; [].each { var ; var = "a"; var } ; var' }
 

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -241,24 +241,59 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating methods, handle internal references' do
+    context 'when annotating methods, handle internal references w.r.t. instance methods' do
       subject(:annotated_node) do
         described_class.annotate(node, headers: headers)
       end
 
       let(:node) { Analist.to_ast('./spec/support/src/klass.rb') }
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
+      let(:instance_random_number_alias_node) do
+        annotated_node.children[2].children[2].children
+      end
+      let(:class_random_number_alias_node) do
+        annotated_node.children[2].children[3].children
+      end
 
-      it { expect(annotated_node.children[2].children[1].children[0]).to eq(:random_number_alias) }
+      it { expect(instance_random_number_alias_node[0]).to eq(:instance_random_number_alias) }
       it do
-        expect(annotated_node.children[2].children[1].children[2].annotation).to eq(
+        expect(instance_random_number_alias_node[2].annotation).to eq(
           Analist::Annotation.new(nil, [], Integer)
         )
       end
 
-      it { expect(annotated_node.children[2].children[3].children[1]).to eq(:qotd_alias) }
+      it { expect(class_random_number_alias_node[1]).to eq(:class_random_number_alias) }
       it do
-        expect(annotated_node.children[2].children[3].children[3].annotation).to eq(
+        expect(class_random_number_alias_node[3].annotation).to eq(
+          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+        )
+      end
+    end
+
+    context 'when annotating methods, handle internal references w.r.t. class methods' do
+      subject(:annotated_node) do
+        described_class.annotate(node, headers: headers)
+      end
+
+      let(:node) { Analist.to_ast('./spec/support/src/klass.rb') }
+      let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
+      let(:instance_qotd_alias_node) do
+        annotated_node.children[2].children[4].children
+      end
+      let(:class_qotd_alias_node) do
+        annotated_node.children[2].children[5].children
+      end
+
+      it { expect(instance_qotd_alias_node[0]).to eq(:instance_qotd_alias) }
+      it do
+        expect(instance_qotd_alias_node[2].annotation).to eq(
+          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+        )
+      end
+
+      it { expect(class_qotd_alias_node[1]).to eq(:class_qotd_alias) }
+      it do
+        expect(class_qotd_alias_node[3].annotation).to eq(
           Analist::Annotation.new(nil, [], String)
         )
       end

--- a/spec/analist/checker_spec.rb
+++ b/spec/analist/checker_spec.rb
@@ -6,55 +6,58 @@ RSpec.describe Analist::Checker do
   end
 
   let(:resources) do
-    { schema: Analist::SQL::Schema.read_from_file('./spec/support/sql/users.sql') }
+    { schema: Analist::SQL::Schema.read_from_file('./spec/support/sql/users.sql'),
+      headers: headers }
   end
+  let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/user.rb') }
+
   let(:expected_annotation) { errors.first.expected_annotation }
   let(:actual_annotation) { errors.first.actual_annotation }
 
   describe '#check' do
-    context 'when parsing an unknown function call' do
+    context 'when checking an unknown function call' do
       let(:expression) { 'unknown_function(arg)' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing an unknown property' do
+    context 'when checking an unknown property' do
       let(:expression) { 'a.unknown_property' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing an unknown property on a primitive type' do
+    context 'when checking an unknown property on a primitive type' do
       let(:expression) { '1.unknown_property' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing a calculation on an unknown property on a Active Record object' do
+    context 'when checking a calculation on an unknown property on a Active Record object' do
       let(:expression) { 'User.first.unknown_property + 1' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing a simple calculation' do
+    context 'when checking a simple calculation' do
       let(:expression) { '1 + 1' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing a simple statement' do
+    context 'when checking a simple statement' do
       let(:expression) { '[1]' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing a nested calculation statement' do
+    context 'when checking a nested calculation statement' do
       let(:expression) { '[1 + 1]' }
 
       it { expect(errors).to eq [] }
     end
 
-    context 'when parsing an invalid method call' do
+    context 'when checking an invalid method call' do
       let(:expression) { '"a".reverse(1)' }
 
       it { expect(errors.first).to be_kind_of Analist::ArgumentError }
@@ -62,15 +65,23 @@ RSpec.describe Analist::Checker do
       it { expect(errors.first.actual_number_of_args).to eq 1 }
     end
 
-    context 'when parsing an invalid simple coercion' do
+    context 'when checking an invalid simple coercion' do
       let(:expression) { '1 + "a"' }
 
       it { expect(expected_annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }
       it { expect(actual_annotation).to eq Analist::Annotation.new(Integer, [String], Integer) }
     end
 
-    context 'when parsing an invalid Active Record property coercion' do
+    context 'when checking an invalid Active Record property coercion' do
       let(:expression) { 'User.first.id + "a"' }
+
+      it { expect(errors.first).to be_kind_of Analist::TypeError }
+      it { expect(expected_annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }
+      it { expect(actual_annotation).to eq Analist::Annotation.new(Integer, [String], Integer) }
+    end
+
+    context 'when checking a variable assignment and multiple references on an object' do
+      let(:expression) { 'var = User.first ; var.id + var.full_name' }
 
       it { expect(errors.first).to be_kind_of Analist::TypeError }
       it { expect(expected_annotation).to eq Analist::Annotation.new(Integer, [Integer], Integer) }

--- a/spec/analist/headerizer_spec.rb
+++ b/spec/analist/headerizer_spec.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Analist::Headerizer do
-  let(:source) { CommonHelpers.parse_file('./spec/support/src/user.rb') }
+  let(:source) { CommonHelpers.parse_file('./spec/support/src/modules_and_classes.rb') }
 
   describe '#headerizer' do
     subject(:header_table) { described_class.headerize([source]) }
 
-    context 'when looking for the SimpleUser class' do
-      it { expect(header_table.retrieve_class('SimpleUser').superklass).to eq '' }
-    end
-
     context 'when looking for the User class' do
-      it { expect(header_table.retrieve_class('User').superklass).to eq 'ActiveRecord::Base' }
+      it { expect(header_table.retrieve_class('User').superklass).to eq '' }
       it { expect(header_table.retrieve_class('User').scope).to be_empty }
-      it { expect(header_table.retrieve_method(:full_name, 'User')).not_to be_nil }
     end
 
     context 'when looking for the BlaatUser class' do
@@ -25,6 +20,7 @@ RSpec.describe Analist::Headerizer do
     context 'when looking for the SuperBlaatUser class' do
       it { expect(header_table.retrieve_class('Blaat::SuperBlaatUser').superklass).to eq 'User' }
       it { expect(header_table.retrieve_class('Blaat::SuperBlaatUser').scope).to eq [:Blaat] }
+      it { expect(header_table.retrieve_method(:method, 'Blaat::SuperBlaatUser')).to be_nil }
       it { expect(header_table.retrieve_method(:full_name, 'Blaat::SuperBlaatUser')).not_to be_nil }
     end
   end

--- a/spec/analist/symbol_table_spec.rb
+++ b/spec/analist/symbol_table_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Analist::SymbolTable do
-  subject(:symbol_table) { Class.new(described_class) }
+  subject(:symbol_table) { described_class.new }
 
   describe '#retrieve' do
     it { expect(symbol_table.retrieve(:var)).to be_nil }

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -1,0 +1,17 @@
+class Klass
+  def random_number
+    4 # See https://xkcd.com/221/
+  end
+
+  def random_number_alias
+    random_number
+  end
+
+  def self.qotd
+    'The problem with UDP jokes: I do not get half of them'
+  end
+
+  def self.qotd_alias
+    qotd
+  end
+end

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -3,15 +3,23 @@ class Klass
     4 # See https://xkcd.com/221/
   end
 
-  def random_number_alias
-    random_number
-  end
-
   def self.qotd
     'The problem with UDP jokes: I do not get half of them'
   end
 
-  def self.qotd_alias
+  def instance_random_number_alias
+    random_number
+  end
+
+  def self.class_random_number_alias
+    random_number
+  end
+
+  def instance_qotd_alias
+    qotd
+  end
+
+  def self.class_qotd_alias
     qotd
   end
 end

--- a/spec/support/src/modules_and_classes.rb
+++ b/spec/support/src/modules_and_classes.rb
@@ -1,0 +1,16 @@
+class User
+  def full_name
+    'Random Stranger'
+  end
+end
+
+module Blaat
+  class BlaatUser < User
+    def method
+      'it exists'
+    end
+  end
+end
+
+class Blaat::SuperBlaatUser < User
+end

--- a/spec/support/src/user.rb
+++ b/spec/support/src/user.rb
@@ -4,4 +4,8 @@ class User < ActiveRecord::Base
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  def self.anonymous_name
+    'Anonymous User'
+  end
 end

--- a/spec/support/src/user.rb
+++ b/spec/support/src/user.rb
@@ -1,27 +1,7 @@
 # frozen_string_literal: true
 
-class SimpleUser; end
-
 class User < ActiveRecord::Base
-  def random_string
-    'lorem ipsum'
-  end
-
-  def random_number
-    4
-  end
-
   def full_name
     "#{first_name} #{last_name}"
   end
 end
-
-module Blaat
-  class BlaatUser < User
-    def method
-      'it exists'
-    end
-  end
-end
-
-class Blaat::SuperBlaatUser < User; end


### PR DESCRIPTION
Add support for cross method references, while making distinction between class and instance methods:

```ruby
class Klass
  def random_number
    4 # See https://xkcd.com/221/
  end

  def random_number_alias
    random_number
  end

  def self.qotd
    'The problem with UDP jokes: I do not get half of them'
  end

  def self.qotd_alias
    qotd
  end
end
```

And class instantiation like:
```ruby
var = Klass.new
var.id
```