### PR TITLE
Handle hashes and rescue blocks properly

### DIFF
--- a/lib/analist/annotations.rb
+++ b/lib/analist/annotations.rb
@@ -14,12 +14,10 @@ module Analist
     def ==(other)
       return false unless other.is_a?(self.class)
 
-      if args_types == [Analist::AnyArgs]
-        return [receiver_type, return_type] == [other.receiver_type, other.return_type]
+      attrs = %i[receiver_type args_types return_type]
+      attrs.all? do |attr|
+        send(attr) == other.send(attr)
       end
-
-      [receiver_type, args_types, return_type] ==
-        [other.receiver_type, other.args_types, other.return_type]
     end
 
     def to_s

--- a/lib/analist/annotations.rb
+++ b/lib/analist/annotations.rb
@@ -82,10 +82,11 @@ module Analist
 
     def primitive_annotations
       {
+        const: ->(node) { Annotation.new(nil, [], type: node.children.last, on: :collection) },
         dstr: ->(_) { Annotation.new(nil, [], String) },
         int: ->(_) { Annotation.new(nil, [], Integer) },
         str: ->(_) { Annotation.new(nil, [], String) },
-        const: ->(node) { Annotation.new(nil, [], type: node.children.last, on: :collection) }
+        sym: ->(_) { Annotation.new(nil, [], Symbol) }
       }
     end
   end

--- a/lib/analist/annotator.rb
+++ b/lib/analist/annotator.rb
@@ -27,21 +27,27 @@ module Analist
         annotate_block(node, resources)
       when :class
         annotate_class(node, resources)
-      when :module
-        annotate_module(node, resources)
       when :def
         annotate_def(node, resources)
       when :defs
         annotate_defs(node, resources)
+      when :hash
+        annotate_hash(node, resources)
       when :if
         annotate_if(node, resources)
+      when :module
+        annotate_module(node, resources)
+      when :pair
+        annotate_pair(node, resources)
+      when :rescue
+        annotate_rescue(node, resources)
       when :send
         annotate_send(node, resources)
       when :lvasgn
         annotate_local_variable_assignment(node, resources)
       when :lvar
         annotate_local_variable(node, resources)
-      when :int, :str, :const, :dstr
+      when :int, :str, :sym, :const, :dstr
         annotate_primitive(node)
       else
         if ENV['ANALIST_DEBUG']
@@ -84,8 +90,12 @@ module Analist
       annotate_block(node, resources, :"self.#{node.children[1]}")
     end
 
+    def annotate_hash(node, resources)
+      annotate_begin(node, resources)
+    end
+
     def annotate_if(node, resources)
-      annotate_block(node, resources)
+      annotate_begin(node, resources)
     end
 
     def annotate_local_variable_assignment(node, resources)
@@ -109,9 +119,17 @@ module Analist
       annotate_block(node, resources, node.children.first)
     end
 
+    def annotate_pair(node, resources)
+      annotate_begin(node, resources)
+    end
+
     def annotate_primitive(node)
       AnnotatedNode.new(node, node.children,
                         Analist::Annotations.primitive_annotations[node.type].call(node))
+    end
+
+    def annotate_rescue(node, resources)
+      annotate_begin(node, resources)
     end
 
     def annotate_send(node, resources)

--- a/lib/analist/annotator.rb
+++ b/lib/analist/annotator.rb
@@ -27,6 +27,8 @@ module Analist
         annotate_def(node, resources)
       when :defs
         annotate_defs(node, resources)
+      when :dstr
+        annotate_dstr(node, resources)
       when :module
         annotate_module(node, resources)
       when :send
@@ -35,7 +37,7 @@ module Analist
         annotate_local_variable_assignment(node, resources)
       when :lvar
         annotate_local_variable(node, resources)
-      when :int, :str, :sym, :const, :dstr
+      when :int, :str, :sym, :const
         annotate_primitive(node)
       else
         annotate_children(node, resources)
@@ -47,16 +49,16 @@ module Analist
                         Analist::Annotation.new(nil, [], Array))
     end
 
-    def annotate_children(node, resources)
-      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
-                        Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown))
-    end
-
     def annotate_block(node, resources, name = nil)
       resources[:symbol_table].enter_scope(name)
       block = annotate_children(node, resources)
       resources[:symbol_table].exit_scope
       block
+    end
+
+    def annotate_children(node, resources)
+      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
+                        Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown))
     end
 
     def annotate_class(node, resources)
@@ -69,6 +71,11 @@ module Analist
 
     def annotate_defs(node, resources)
       annotate_block(node, resources, :"self.#{node.children[1]}")
+    end
+
+    def annotate_dstr(node, resources)
+      AnnotatedNode.new(node, node.children.map { |n| annotate(n, resources) },
+                        Analist::Annotation.new(nil, [], String))
     end
 
     def annotate_local_variable_assignment(node, resources)

--- a/lib/analist/annotator.rb
+++ b/lib/analist/annotator.rb
@@ -75,7 +75,10 @@ module Analist
       annotated_children = node.children.map { |n| annotate(n, resources) }
       variable, value = annotated_children
 
-      return unless value
+      unless value
+        return AnnotatedNode.new(node, annotated_children,
+                                 Analist::Annotation.new(nil, [], AnnotationTypeUnknown))
+      end
 
       resources[:symbol_table].store(variable, value.annotation)
 

--- a/lib/analist/checker.rb
+++ b/lib/analist/checker.rb
@@ -7,72 +7,19 @@ module Analist
   module Checker
     module_function
 
-    def check(node) # rubocop:disable Metrics/CyclomaticComplexity
-      return [] unless node.respond_to?(:type)
+    def check(node)
+      return [] unless node.is_a?(Analist::AnnotatedNode)
 
       case node.type
-      when :begin
-        check_begin(node)
-      when :block
-        check_block(node)
-      when :class
-        check_class(node)
-      when :def
-        check_def(node)
-      when :defs
-        check_defs(node)
-      when :if
-        check_if(node)
-      when :module
-        check_module(node)
       when :send
         check_send(node)
-      when :array
-        check_array(node)
-      when :int, :str, :const
-        return
       else
-        if ENV['ANALIST_DEBUG']
-          raise NotImplementedError, "Node type `#{node.type}` cannot be checked"
-        end
-        []
+        check_children(node)
       end
-    end
-
-    def check_array(node)
-      check_children(node)
-    end
-
-    def check_begin(node)
-      check_children(node)
-    end
-
-    def check_block(node)
-      check_children(node)
     end
 
     def check_children(node)
       node.children.flat_map { |n| check(n) }.compact
-    end
-
-    def check_class(node)
-      check_children(node)
-    end
-
-    def check_def(node)
-      check_children(node)
-    end
-
-    def check_defs(node)
-      check_children(node)
-    end
-
-    def check_if(node)
-      check_children(node)
-    end
-
-    def check_module(node)
-      check_children(node)
     end
 
     def check_send(node)

--- a/lib/analist/checker.rb
+++ b/lib/analist/checker.rb
@@ -28,14 +28,16 @@ module Analist
       return [] if node.annotation.return_type[:type] == Analist::AnnotationTypeUnknown
 
       receiver, _method_name, *args = node.children
-      expected_annotation = node.annotation
+      expected_args = node.annotation.args_types.flat_map { |a| a.respond_to?(:annotation) ? a.annotation.return_type[:type] : a }
+      expected_annotation = Analist::Annotation.new(node.annotation.receiver_type,
+                                                    expected_args, node.annotation.return_type)
 
       actual_annotation = Analist::Annotation.new(
         receiver&.annotation&.return_type, args.flat_map { |a| a.annotation.return_type[:type] },
         node.annotation.return_type
       )
 
-      if expected_annotation != actual_annotation
+      if significant_difference?(expected_annotation, actual_annotation)
         error = if expected_annotation.args_types.count != actual_annotation.args_types.count
                   Analist::ArgumentError.new(node, expected_number_of_args:
                                                      expected_annotation.args_types.count,
@@ -49,6 +51,22 @@ module Analist
       end
 
       [error, check(receiver), args.flat_map { |a| check(a) }.compact].compact.flatten
+    end
+
+    def significant_difference?(annotation, other_annotation) # rubocop:disable Metrics/PerceivedComplexity Metrics/LineLength
+      attrs = %i[receiver_type args_types return_type]
+      attrs.delete(:args_types) if annotation.args_types.any? { |t| t == Analist::AnnotationTypeUnknown } ||
+                                   annotation.args_types == [Analist::AnyArgs] ||
+                                   other_annotation.args_types.any? { |t| t == Analist::AnnotationTypeUnknown } ||
+                                   other_annotation.args_types == [Analist::AnyArgs]
+      %i[receiver_type return_type].each do |field|
+        attrs.delete(field) if annotation.send(field)[:type] == Analist::AnnotationTypeUnknown ||
+                               other_annotation.send(field)[:type] == Analist::AnnotationTypeUnknown
+      end
+
+      attrs.any? do |attr|
+        annotation.send(attr) != other_annotation.send(attr)
+      end
     end
   end
 end

--- a/lib/analist/checker.rb
+++ b/lib/analist/checker.rb
@@ -28,7 +28,9 @@ module Analist
       return [] if node.annotation.return_type[:type] == Analist::AnnotationTypeUnknown
 
       receiver, _method_name, *args = node.children
-      expected_args = node.annotation.args_types.flat_map { |a| a.respond_to?(:annotation) ? a.annotation.return_type[:type] : a }
+      expected_args = node.annotation.args_types.flat_map do |a|
+        a.respond_to?(:annotation) ? a.annotation.return_type[:type] : a
+      end
       expected_annotation = Analist::Annotation.new(node.annotation.receiver_type,
                                                     expected_args, node.annotation.return_type)
 
@@ -53,7 +55,8 @@ module Analist
       [error, check(receiver), args.flat_map { |a| check(a) }.compact].compact.flatten
     end
 
-    def significant_difference?(annotation, other_annotation) # rubocop:disable Metrics/PerceivedComplexity Metrics/LineLength
+    # rubocop:disable Metrics/LineLength
+    def significant_difference?(annotation, other_annotation) # rubocop:disable Metrics/CyclomaticComplexity
       attrs = %i[receiver_type args_types return_type]
       attrs.delete(:args_types) if annotation.args_types.any? { |t| t == Analist::AnnotationTypeUnknown } ||
                                    annotation.args_types == [Analist::AnyArgs] ||
@@ -68,5 +71,6 @@ module Analist
         annotation.send(attr) != other_annotation.send(attr)
       end
     end
+    # rubocop:enable Metrics/LineLength
   end
 end

--- a/lib/analist/resolve_lookup.rb
+++ b/lib/analist/resolve_lookup.rb
@@ -17,9 +17,13 @@ module Analist
         return unless @headers
         return unless last_statement
 
-        return if @symbol_table.scope.include?(@method)
+        lookup_chain = @resources.fetch(:lookup_chain, [])
+        return if lookup_chain.include?(@method)
 
-        Analist::Annotator.annotate(last_statement, @resources).annotation.return_type
+        @resources[:lookup_chain] = lookup_chain + [@method]
+        return_type = Analist::Annotator.annotate(last_statement, @resources).annotation.return_type
+        @resources.delete(:lookup_chain)
+        return_type
       end
 
       def klass_method?

--- a/lib/analist/resolve_lookup.rb
+++ b/lib/analist/resolve_lookup.rb
@@ -17,6 +17,8 @@ module Analist
         return unless @headers
         return unless last_statement
 
+        return if @symbol_table.scope.include?(@method)
+
         Analist::Annotator.annotate(last_statement, @resources).annotation.return_type
       end
 

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -261,6 +261,9 @@ RSpec.describe Analist::Annotator do
       let(:class_random_number_alias_node) do
         annotated_node.children[2].children[3].children
       end
+      let(:recursive_node) do
+        annotated_node.children[2].children[6].children
+      end
 
       it { expect(instance_random_number_alias_node[0]).to eq(:instance_random_number_alias) }
       it do
@@ -272,6 +275,13 @@ RSpec.describe Analist::Annotator do
       it { expect(class_random_number_alias_node[1]).to eq(:class_random_number_alias) }
       it do
         expect(class_random_number_alias_node[3].annotation).to eq(
+          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+        )
+      end
+
+      it { expect(recursive_node[0]).to eq(:recursive_method) }
+      it do
+        expect(recursive_node[2].annotation).to eq(
           Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
         )
       end

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -248,71 +248,84 @@ RSpec.describe Analist::Annotator do
       end
     end
 
-    context 'when annotating methods, handle internal references w.r.t. instance methods' do
+    context 'when annotating klass.rb' do
       subject(:annotated_node) do
         described_class.annotate(node, resources)
       end
 
       let(:node) { Analist.parse_file('./spec/support/src/klass.rb') }
       let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
-      let(:instance_random_number_alias_node) do
-        annotated_node.children[2].children[2].children
-      end
-      let(:class_random_number_alias_node) do
-        annotated_node.children[2].children[3].children
-      end
-      let(:recursive_node) do
-        annotated_node.children[2].children[6].children
+
+      context 'when annotating methods, handle internal references w.r.t. instance methods' do
+        let(:instance_random_number_alias_node) do
+          annotated_node.children[2].children[2].children
+        end
+        let(:class_random_number_alias_node) do
+          annotated_node.children[2].children[3].children
+        end
+
+        it { expect(instance_random_number_alias_node[0]).to eq(:instance_random_number_alias) }
+        it do
+          expect(instance_random_number_alias_node[2].annotation).to eq(
+            Analist::Annotation.new(nil, [], Integer)
+          )
+        end
+
+        it { expect(class_random_number_alias_node[1]).to eq(:class_random_number_alias) }
+        it do
+          expect(class_random_number_alias_node[3].annotation).to eq(
+            Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+          )
+        end
       end
 
-      it { expect(instance_random_number_alias_node[0]).to eq(:instance_random_number_alias) }
-      it do
-        expect(instance_random_number_alias_node[2].annotation).to eq(
-          Analist::Annotation.new(nil, [], Integer)
-        )
+      context 'when annotating methods, handle internal references w.r.t. class methods' do
+        let(:instance_qotd_alias_node) do
+          annotated_node.children[2].children[4].children
+        end
+        let(:class_qotd_alias_node) do
+          annotated_node.children[2].children[5].children
+        end
+
+        it { expect(instance_qotd_alias_node[0]).to eq(:instance_qotd_alias) }
+        it do
+          expect(instance_qotd_alias_node[2].annotation).to eq(
+            Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+          )
+        end
+
+        it { expect(class_qotd_alias_node[1]).to eq(:class_qotd_alias) }
+        it do
+          expect(class_qotd_alias_node[3].annotation).to eq(
+            Analist::Annotation.new(nil, [], String)
+          )
+        end
       end
 
-      it { expect(class_random_number_alias_node[1]).to eq(:class_random_number_alias) }
-      it do
-        expect(class_random_number_alias_node[3].annotation).to eq(
-          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
-        )
+      context 'when annotating recursive methods' do
+        subject(:recursive_node) do
+          annotated_node.children[2].children[6].children
+        end
+
+        it { expect(recursive_node[0]).to eq(:recursive_method) }
+        it do
+          expect(recursive_node[2].annotation).to eq(
+            Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+          )
+        end
       end
 
-      it { expect(recursive_node[0]).to eq(:recursive_method) }
-      it do
-        expect(recursive_node[2].annotation).to eq(
-          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
-        )
-      end
-    end
+      context 'when annotating rescued methods' do
+        subject(:recursive_node) do
+          annotated_node.children[2].children[7].children
+        end
 
-    context 'when annotating methods, handle internal references w.r.t. class methods' do
-      subject(:annotated_node) do
-        described_class.annotate(node, resources)
-      end
-
-      let(:node) { Analist.parse_file('./spec/support/src/klass.rb') }
-      let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
-      let(:instance_qotd_alias_node) do
-        annotated_node.children[2].children[4].children
-      end
-      let(:class_qotd_alias_node) do
-        annotated_node.children[2].children[5].children
-      end
-
-      it { expect(instance_qotd_alias_node[0]).to eq(:instance_qotd_alias) }
-      it do
-        expect(instance_qotd_alias_node[2].annotation).to eq(
-          Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
-        )
-      end
-
-      it { expect(class_qotd_alias_node[1]).to eq(:class_qotd_alias) }
-      it do
-        expect(class_qotd_alias_node[3].annotation).to eq(
-          Analist::Annotation.new(nil, [], String)
-        )
+        it { expect(recursive_node[0]).to eq(:rescued_method) }
+        it do
+          expect(recursive_node[2].annotation).to eq(
+            Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+          )
+        end
       end
     end
 

--- a/spec/analist/annotator_spec.rb
+++ b/spec/analist/annotator_spec.rb
@@ -315,9 +315,22 @@ RSpec.describe Analist::Annotator do
         end
       end
 
-      context 'when annotating rescued methods' do
+      context 'when annotating methods recursive methods' do
         subject(:recursive_node) do
           annotated_node.children[2].children[7].children
+        end
+
+        it { expect(recursive_node[0]).to eq(:calling_recursive_method) }
+        it do
+          expect(recursive_node[2].annotation).to eq(
+            Analist::Annotation.new(nil, [], Analist::AnnotationTypeUnknown)
+          )
+        end
+      end
+
+      context 'when annotating rescued methods' do
+        subject(:recursive_node) do
+          annotated_node.children[2].children[8].children
         end
 
         it { expect(recursive_node[0]).to eq(:rescued_method) }

--- a/spec/analist/checker_spec.rb
+++ b/spec/analist/checker_spec.rb
@@ -121,5 +121,12 @@ RSpec.describe Analist::Checker do
         )
       end
     end
+
+    context 'when checking a method with a dynamic string as return value' do
+      let(:headers) { Analist::HeaderTable.read_from_file('./spec/support/src/klass.rb') }
+      let(:expression) { 'Klass.method_with_argument(arg)' }
+
+      it { expect(errors).to be_empty }
+    end
   end
 end

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -27,6 +27,10 @@ class Klass
     recursive_method
   end
 
+  def calling_recursive_method
+    recursive_method
+  end
+
   def rescued_method
   rescue Error => _e
   end

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -26,4 +26,8 @@ class Klass
   def recursive_method
     recursive_method
   end
+
+  def rescued_method
+  rescue Error => _e
+  end
 end

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -22,4 +22,8 @@ class Klass
   def self.class_qotd_alias
     qotd
   end
+
+  def recursive_method
+    recursive_method
+  end
 end

--- a/spec/support/src/klass.rb
+++ b/spec/support/src/klass.rb
@@ -34,4 +34,8 @@ class Klass
   def rescued_method
   rescue Error => _e
   end
+
+  def self.method_with_argument(arg)
+    "#{arg}"
+  end
 end


### PR DESCRIPTION
As @sybe pointed out, both:
```ruby
{ collection_date_interval: "a" + 8 + 'a' }
```

and

```ruby
def collect_payment
  "a" + 1
(...)
rescue ArgumentError => e
(...)
end
```

were unsupported. They are now.